### PR TITLE
feat(chaosymmetry): implemented panning with arrow keys

### DIFF
--- a/rust/chaosymmetry/src/chaos.rs
+++ b/rust/chaosymmetry/src/chaos.rs
@@ -63,12 +63,19 @@ impl ChaosEngine {
     }
 }
 
+#[derive(Default)]
+pub struct Position {
+    pub horizontal: isize,
+    pub vertical: isize,
+}
+
 pub struct Renderer {
     pub win_width: usize,
     pub scale: f64,
     color_scale: Box<dyn ColorScale>,
     color_palette: Box<dyn Palette>,
     freq: SharedFreqMap,
+    pub position: Position,
 }
 
 impl Renderer {
@@ -85,6 +92,7 @@ impl Renderer {
             color_scale,
             color_palette,
             freq,
+            position: Position::default(),
         }
     }
 
@@ -112,8 +120,10 @@ impl Renderer {
             let win_x = i % self.win_width;
             let win_y = i / self.win_width;
 
-            let sim_start_x = ((win_x as f64 / self.scale) + offset_x) as i64;
-            let sim_start_y = ((win_y as f64 / self.scale) + offset_y) as i64;
+            let sim_start_x =
+                ((win_x as f64 / self.scale) + offset_x + self.position.horizontal as f64) as i64;
+            let sim_start_y =
+                ((win_y as f64 / self.scale) + offset_y + self.position.vertical as f64) as i64;
 
             let freq = (sim_start_y.max(0)..(sim_start_y + freqs_per_px).clamp(0, sim_height - 1))
                 .map(|row| {

--- a/rust/chaosymmetry/src/main.rs
+++ b/rust/chaosymmetry/src/main.rs
@@ -31,6 +31,7 @@ const HEIGHT: usize = 2234 / 2;
 const SIM_WIDTH: usize = 10_000;
 const SIM_HEIGHT: usize = 10_000;
 const ZOOM_FACTOR: f64 = 1.25;
+const PAN_STEP: isize = 100;
 
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
@@ -192,6 +193,22 @@ impl ApplicationHandler for App {
                     let filename = format!("{}.png", Local::now().to_rfc3339());
                     let path = Path::new(&filename);
                     save_png(data, self.render.win_width, path);
+                } else if event.logical_key == Key::Named(winit::keyboard::NamedKey::ArrowUp)
+                    && event.state.is_pressed()
+                {
+                    self.render.position.vertical -= PAN_STEP;
+                } else if event.logical_key == Key::Named(winit::keyboard::NamedKey::ArrowDown)
+                    && event.state.is_pressed()
+                {
+                    self.render.position.vertical += PAN_STEP;
+                } else if event.logical_key == Key::Named(winit::keyboard::NamedKey::ArrowRight)
+                    && event.state.is_pressed()
+                {
+                    self.render.position.horizontal += PAN_STEP;
+                } else if event.logical_key == Key::Named(winit::keyboard::NamedKey::ArrowLeft)
+                    && event.state.is_pressed()
+                {
+                    self.render.position.horizontal -= PAN_STEP;
                 }
             }
             _ => (),


### PR DESCRIPTION
Implemented support for panning horizontally and vertically. The Renderer now has a position attribute that centers the image being drawn by default; this position can be changed by using the arrow keys.